### PR TITLE
Add page shuffling

### DIFF
--- a/src/components/cards/Cards.jsx
+++ b/src/components/cards/Cards.jsx
@@ -2,11 +2,22 @@ import { useEffect, useState } from "react";
 
 function Cards() {
   const [images, setImages] = useState([]);
-  const [imageId, setImageId] = useState([]);
+  const [imageId, setImageId] = useState([]); // Store the clicked image IDs
   const API_KEY = import.meta.env.VITE_PEXELS_API_KEY;
 
-  const handleClick = () => {
-    console.log("image clicked!");
+  // Function to handle image click
+  const handleClick = (id) => {
+    console.log("image clicked:", id);
+
+    if (imageId.includes(id)) {
+      console.log("Already clicked! Ressetting...");
+      setImageId([]); // Reset if the same image is clicked again
+    } else {
+      setImageId([...imageId, id]); // Stores the clicked image ID
+    }
+
+    // Shuffle images after click
+    setImages((prevImages) => [...prevImages].sort(() => Math.random() - 0.5));
   };
 
   useEffect(() => {
@@ -47,7 +58,7 @@ function Cards() {
                 src={image.src.medium}
                 alt={image.photographer}
                 className="w-full h-auto"
-                onClick={handleClick}
+                onClick={() => handleClick(image.id)}
               />
               <p className="p-2 text-sm text-gray-600">{image.photographer}</p>
             </div>


### PR DESCRIPTION
imageId state variable to store the clicked image IDs handleClick function takes in the id and logs the id to the console check if imageId state variable includes the id then if true call the setImageId setter function to reset imageId to an empty array else store the clicked image id by spreading into a new array and trigger React's re-rendering

added shuffling
prevImages represents the curent state of the images array before updating [...prevImages] creates a new copy of the prevImages array .sort() to shuffle the array with Math.random() - 0.5 to generate a random number between -0.5 and 0.5 which randomly determines the sorting order. setImages(...) to update the state with the newly shuffled images to trigger the re-render